### PR TITLE
update to 7.2.1; add ARG SONAR_VERSION

### DIFF
--- a/5.6.7-alpine/Dockerfile
+++ b/5.6.7-alpine/Dockerfile
@@ -1,6 +1,7 @@
 FROM openjdk:8-alpine
 
-ENV SONAR_VERSION=5.6.7 \
+ARG SONAR_VERSION=5.6.7
+ENV SONAR_VERSION=$SONAR_VERSION \
     SONARQUBE_HOME=/opt/sonarqube \
     # Database configuration
     # Defaults to using H2

--- a/5.6.7/Dockerfile
+++ b/5.6.7/Dockerfile
@@ -1,6 +1,7 @@
 FROM openjdk:8
 
-ENV SONAR_VERSION=5.6.7 \
+ARG SONAR_VERSION=5.6.7
+ENV SONAR_VERSION=$SONAR_VERSION \
     SONARQUBE_HOME=/opt/sonarqube \
     # Database configuration
     # Defaults to using H2

--- a/6.7.4-alpine/Dockerfile
+++ b/6.7.4-alpine/Dockerfile
@@ -1,6 +1,7 @@
 FROM openjdk:8-alpine
 
-ENV SONAR_VERSION=6.7.4 \
+ARG SONAR_VERSION=6.7.4
+ENV SONAR_VERSION=$SONAR_VERSION \
     SONARQUBE_HOME=/opt/sonarqube \
     # Database configuration
     # Defaults to using H2

--- a/6.7.4/Dockerfile
+++ b/6.7.4/Dockerfile
@@ -1,6 +1,7 @@
 FROM openjdk:8
 
-ENV SONAR_VERSION=6.7.4 \
+ARG SONAR_VERSION=6.7.4
+ENV SONAR_VERSION=$SONAR_VERSION \
     SONARQUBE_HOME=/opt/sonarqube \
     # Database configuration
     # Defaults to using H2

--- a/7.2-alpine/Dockerfile
+++ b/7.2-alpine/Dockerfile
@@ -1,6 +1,7 @@
 FROM openjdk:8-alpine
 
-ENV SONAR_VERSION=7.2 \
+ARG SONAR_VERSION=7.2.1
+ENV SONAR_VERSION=$SONAR_VERSION \
     SONARQUBE_HOME=/opt/sonarqube \
     # Database configuration
     # Defaults to using H2

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -1,6 +1,7 @@
 FROM openjdk:8
 
-ENV SONAR_VERSION=7.2 \
+ARG SONAR_VERSION=7.2.1
+ENV SONAR_VERSION=$SONAR_VERSION \
     SONARQUBE_HOME=/opt/sonarqube \
     # Database configuration
     # Defaults to using H2


### PR DESCRIPTION
As this repo is somewhat only used as a temporary solution before SonarQube works out their distribution issue (SonarSource/docker-sonarqube#182), I reckon it would be better to add an `ARG SONAR_VERSION` to make the build process more flexible, so that this repo doesn't need to be updated every time when there's a new version coming out.